### PR TITLE
Nsight and NVTX docs.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -223,3 +223,7 @@ dummy:
 	$(SPHINXBUILD) -b dummy $(ALLSPHINXOPTS) $(BUILDDIR)/dummy
 	@echo
 	@echo "Build finished. Dummy builder generates no files."
+
+.PHONY: livehtml
+livehtml:
+	sphinx-autobuild -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,7 @@
-
+#####################################
 Sheffield GPU Hackathon Documentation
-===============================
+#####################################
+
 This is a collection of useful pieces of documentation for the Sheffield GPU Hackathon. User contributions are encouraged.
 
 .. image:: https://readthedocs.org/projects/gpuhackshef/badge/?version=latest
@@ -8,73 +9,85 @@ This is a collection of useful pieces of documentation for the Sheffield GPU Hac
   :alt: Documentation Status
 
 
+*****************
 How to Contribute
------------------
-To contribute to this documentation, first you have to fork it on GitHub and clone it to your machine, see `Fork a Repo <https://help.github.com/articles/fork-a-repo/>`_ for the GitHub documentation on this process.
+*****************
 
-Once you have the git repository locally on your computer, you will need to install ``sphinx`` and ``sphinx_bootstrap_theme`` to be able to build the documentation. See the instructions below for how to achieve this.
+To contribute to this documentation, first create a fork of the repository on GitHub and clone it to your local machine, see `Fork a Repo <https://help.github.com/articles/fork-a-repo/>`_ for the GitHub documentation on this process.
+
+Once you have cloned your fork, you will need to install the dependencies to be able to build the documentation. See the instructions below for how to achieve this.
+
+Once you have made your changes, commited them and pushed them to your fork on GitHub you will need to `Open a Pull Request <https://help.github.com/articles/using-pull-requests/>`_. All changes to the repository should be made through Pull Requests, including those made by the people with direct push access.
+Using feature branches is recommended.
+
+
+***********************
+Installing Dependencies
+***********************
+
+This documentation requires ``python`` and the python packages ``sphinx`` and ``sphinx_rtd_theme``, as listed in ``requirements.txt``.
+This would be typically done using a `Python Virtual Environment <https://docs.python.org/3/tutorial/venv.html>`_, or `conda <https://docs.conda.io/en/latest/>`_ 
+
+
+Using a python ``venv`` 
+=======================
 
 ::
 
-	pip install sphinx_rtd_theme
+    mkdir -m 700 -p ~/.venvs
+    python3 -m venv ~/.venvs/gpuhacksheffield
+    source ~/.venvs/gpuhacksheffield/bin/activate
+    pip install -r requirements.txt
 
-Once you have made your changes and updated your Fork on GitHub you will need to `Open a Pull Request <https://help.github.com/articles/using-pull-requests/>`_. All changes to the repository should be made through Pull Requests, including those made by the people with direct push access.
+
+Using conda (windows)
+=====================
+
+From a conda-enabled terminal: 
+
+::
+
+    conda create --name gpuhacksheffield python=3
+    conda activate gpuhacksheffield
+    pip install -r requirements.txt
 
 
+**************************
 Building the documentation
-##########################
+**************************
 
-#. Install Python on your machine
-
-#. Install sphinx: ::
-
-	pip install sphinx
-
-   or ::
-
-        conda install sphinx
-
-#. Install sphinx_rtd_theme: ::
-
-	pip install sphinx_rtd_theme
-
-   or ::
-
-        conda install sphinx_rtd_theme
-
-#. To build the HTML documentation run: ::
+To build the HTML documentation run the following from a shell with the ``gpuhacksheffield`` environment enabled: ::
 
     make html
 
-   Or if you don't have the ``make`` utility installed on your machine then build with *sphinx* directly: ::
+Or if you don't have the ``make`` utility installed on your machine then build with *sphinx* directly: ::
 
     sphinx-build . ./html
 
 
 
 Continuous build and serve
-##########################
+==========================
 
-The package `sphinx-autobuild <https://github.com/GaretJax/sphinx-autobuild>`_ provides a watcher that automatically rebuilds the site as files are modified. To use it, install (in addition to the Sphinx packages) with the following: ::
+The package `sphinx-autobuild <https://github.com/GaretJax/sphinx-autobuild>`_ provides a watcher that automatically rebuilds the site as files are modified.
 
-    pip install sphinx-autobuild
+To start the autobuild process, from a shell with the ``gpuhacksheffield`` environment enabled run: ::
 
-To start the autobuild process, run: ::
+    make livehtml
+
+Or if you don't have the ``make`` utility installed on your machine then build with *sphinx-autobuild* directly: ::
 
     sphinx-autobuild . ./html
 
 The application also serves up the site at port ``8000`` by default at http://localhost:8000.
 
 
+***********************************
 Making Changes to the Documentation
------------------------------------
+***********************************
 
-The documentation consists of a series of `reStructured Text <http://sphinx-doc.org/rest.html>`_ files which have the ``.rst`` extension. These files are then automatically converted to HTMl and combined into the web version of the documentation by sphinx. It is important that when editing the files the syntax of the rst files is followed.
+The documentation consists of a series of `reStructured Text <http://sphinx-doc.org/rest.html>`_ files which have the ``.rst`` extension. These files are then automatically converted to HTML and combined into the web version of the documentation by sphinx. It is important that when editing the files the syntax of the rst files is followed.
 
 
-If there are any errors in your changes the build will fail and the documentation  will not update, you can test your build locally by running ``make html``. The easiest way to learn what files should look like is to read the ``rst`` files already in the repository.
+If there are any errors in your changes the build will fail and the documentation will not update, you can test your build locally by running ``make html``. The easiest way to learn what files should look like is to read the ``rst`` files already in the repository.
 
-Submitting Changes and Making Contributions
--------------------------------------------
-
-Contributions should be made by forking the documentation site repo (this repo) and submitting a pull request. Pull requests will be merged by an Admin after review. 

--- a/index.rst
+++ b/index.rst
@@ -31,3 +31,5 @@ The site encourages user contributions via `GitHub <https://github.com/GPUHackSh
    nvidia-system/index
    bede/index
    training/index
+   tools/nvidia-profiling-tools
+   tools/nvidia-tools-extension

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 sphinx==1.5.3  # should be same version as currently used by ReadTheDocs
 sphinx_rtd_theme>=0.2.4
+sphinx-autobuild

--- a/tools/nvidia-profiling-tools.rst
+++ b/tools/nvidia-profiling-tools.rst
@@ -1,0 +1,121 @@
+.. _NVIDIA_Profiling_Tools:
+
+NVIDIA Profiling Tools
+======================
+
+HPC systems typically favour batch jobs rather than interactive jobs for improved utilsation of resources. 
+The Nvidia profiling tools can all be used to capture all required via the command line, which can then be interrogated using the GUI tools locally.
+
+Nsight Systems and Nsight Compute are the modern Nvidia profiling tools, introduced with CUDA 10.0 supporting Pascal+ and Volta+ respectivley.
+
+The NVIDIA Visual Profiler is the legacy profiling tool, with full support for GPUs up to pascal (SM < 75), partial support for Turing (SM 75 and no support for Ampere (SM80).
+
+
+Compiler settings for profiling
+-------------------------------
+
+Applications compiled with ``nvcc`` should pass ``-lineinfo`` (or ``--generate-line-info``) to include source-level profile information. 
+
+Additionally, `NVIDIA Tools Extension SDK <https://docs.nvidia.com/gameworks/index.html#gameworkslibrary/nvtx/nvidia_tools_extension_library_nvtx.htm>`_ can be used to enhance these profiling tools.
+
+
+Nsight Systems and Nsight Compute
+---------------------------------
+
+.. note:: 
+    * Nsight Systems supports Pascal and above (SM 60+)
+    * Nsight Compute supports Volta and aboce (SM 70+)
+
+Generate an application timeline with Nsight Systems CLI (``nsys``):
+
+.. code-block:: bash
+
+   nsys profile -o timeline ./myapplication
+
+Use the ``--trace`` argument to specify which APIs should be traced. 
+See the `nsys profiling command switch options <https://docs.nvidia.com/nsight-systems/profiling/index.html#cli-profile-command-switch-options>`_ for further information.
+
+.. code-block:: bash
+
+   nsys profile -o timeline --trace cuda,nvtx,osrt,openacc ./myapplication <arguments>
+
+
+Once this file has been downloaded to your local machine, it can be opened in ``nsight-sys`` via ``File > Open > timeline.qdrep``: 
+
+
+Fine-grained kernel profile information can be captured using remote Nsight Compute CLI (``nv-nsight-cu-cli``):
+
+.. code-block:: bash
+   
+   nv-nsight-cu-cli -o profile --set full ./myapplication <arguments>
+
+
+This will capture the full set of available metrics, to populate all sections of the Nsight Compute GUI, however this can lead to very long run times to capture all the information.
+
+For long running applications, it may be favourable to capture a smaller set of metrics using the ``--set``, ``--section`` and ``--metrics`` flags as described in the `Nsight Comptue Profile Command Line Options table <https://docs.nvidia.com/nsight-compute/NsightComputeCli/index.html#command-line-options-profile>`_.
+
+The scope of the section being profiled can also be reduced using `NVTX Filtering <https://docs.nvidia.com/nsight-compute/NsightComputeCli/index.html#nvtx-filtering>`_; or by targetting specific kernels using ``--kernel-id``, ``--kernel-regex`` and/or ``--launch-skip`` see the `CLI docs for more information <https://docs.nvidia.com/nsight-compute/NsightComputeCli/index.html#command-line-options-profile>`_).
+
+
+Once the ``.ncu-rep`` file has been downloaded locally, it can be imported into local Nsight CUDA GUI ``nv-nsight-cu`` via: 
+
+.. code-block:: bash
+
+   nv-nsight-cu profile.ncu-rep
+
+
+**Or** ``File > Open > profile.ncu-rep``, **or** Drag ``profile.ncu-rep`` into the ``nv-nsight-cu`` window.
+
+.. note:: 
+   Older versions of Nsight Compute generated ``.nsight-cuprof-report`` files, instead of ``.ncu-rep`` files.
+
+
+Documentation
+^^^^^^^^^^^^^
+
++ `Nsight Systems <https://docs.nvidia.com/nsight-systems/>`_
++ `Nsight Compute <https://docs.nvidia.com/nsight-compute/>`_
+
+Training Material
+^^^^^^^^^^^^^^^^^
+* `OLCF: Nsight Systems Tutorial <https://vimeo.com/398838139>`_
+* `OLCF: Nsight Compute Tutorial <https://vimeo.com/398929189>`_
+
+Use the following `Nsight report files <https://drive.google.com/open?id=133a90SIupysHfbO3mlyfXfaEivCyV1EP>`_ to follow the tutorial.
+
+
+Visual Profiler (legacy)
+------------------------
+.. note::
+   * Nvprof does not support CUDA kernel profiling for Turing GPUs (SM75)
+   * Nvprof does not support Ampere GPUs (SM80+)
+
+Application timelines can be generated using ``nvprof``:
+
+.. code-block:: bash
+
+   nvprof -o timeline.nvprof ./myapplication
+
+
+Fine-grained kernel profile information can be genereted remotely using ``nvprof``:
+
+.. code-block:: bash
+
+   nvprof --analysis-metrics -o analysis.nvprof ./myapplication
+
+This captuires the full set of metrics required to complete the guided analysis, and may take a (very long) while. 
+Large applications request fewer metrics (via ``--metrics``), fewer events (via ``--events``) or target specific kernels (via ``--kernels``). See the `nvprof command line options <https://docs.nvidia.com/cuda/profiler-users-guide/index.html>`_ for further information.
+
+Once these files are downloaded to your local machine, Import them into the Visual Profiler GUI (``nvvp``)
+
++ ``File > Import``
++ Select ``Nvprof``
++ Select ``Single process``
++ Select ``timeline.nvvp`` for ``Timeline data file``
++ Add ``analysis.nvprof`` to ``Event/Metric data files``
+
+
+Documentation
+^^^^^^^^^^^^^
+
++ `Nvprof Documentation <https://docs.nvidia.com/cuda/profiler-users-guide/index.html>`_

--- a/tools/nvidia-tools-extension.rst
+++ b/tools/nvidia-tools-extension.rst
@@ -1,0 +1,33 @@
+.. _NVIDIA_Tools_Extension:
+
+NVIDIA Tools Extension
+======================
+
+NVIDIA Tools Extension (NVTX) is a C-based API for annotating events and ranges in applications.
+These markers and ranges can be used to increase the usability of the NVIDIA profiling tools.
+
+
+* For CUDA ``>= 10.0``, NVTX version 3 is distributed as a header only library.
+* For CUDA ``<  10.0``, NVTX is distributed as a shared library.
+
+The location of the headers and shared libraries may vary between Operating Systems, and CUDA installation (i.e. CUDA toolkit, PGI compilers or HPC SDK).
+
+
+
+The NVIDIA Developer blog contains several posts on using NVTX:
+
+* `Generate Custom Application Profile Timelines with NVTX (Jiri Kraus) <https://developer.nvidia.com/blog/cuda-pro-tip-generate-custom-application-profile-timelines-nvtx/>`_ 
+* `Track MPI Calls In The NVIDIA Visual Profiler (Jeff Larkin) <https://developer.nvidia.com/blog/gpu-pro-tip-track-mpi-calls-nvidia-visual-profiler/>`_ 
+* `Customize CUDA Fortran Profiling with NVTX (Massimiliano Fatica) <https://developer.nvidia.com/blog/customize-cuda-fortran-profiling-nvtx/>`_
+
+
+
+Custom CMake ``find_package`` modules can be written to enable use within Cmake e.g. `ptheywood/cuda-cmake-NVTX on GitHub <https://github.com/ptheywood/cuda-cmake-nvtx>`_
+
+
+
+Documentation
+-------------
+
++ `NVTX Documentation <https://docs.nvidia.com/gameworks/index.html#gameworkslibrary/nvtx/nvidia_tools_extension_library_nvtx.htm>`_
++ `NVTX 3 on GitHub <https://github.com/NVIDIA/NVTX>`_


### PR DESCRIPTION
Adds some docs on remote use of nsight systems, nsight compute and nvprof (for older GPU architectures), based on last years version. 

Also adds information and links on NVTX

Updates the readme to provide insturctions for using python venv / conda environment. 