### PR TITLE
Minor tweak to nsight compute docs post CUDA 11.0.194

### DIFF
--- a/tools/nvidia-profiling-tools.rst
+++ b/tools/nvidia-profiling-tools.rst
@@ -87,6 +87,11 @@ Training Material
 Use the following `Nsight report files <https://drive.google.com/open?id=133a90SIupysHfbO3mlyfXfaEivCyV1EP>`_ to follow the tutorial.
 
 
+Cluster Modules
+^^^^^^^^^^^^^^^
+* :ref:`raplab-hackathon<hackathon_facility>`: ``module load nvcompilers/2020``
+
+
 Visual Profiler (legacy)
 ------------------------
 .. note::
@@ -122,3 +127,7 @@ Documentation
 ^^^^^^^^^^^^^
 
 + `Nvprof Documentation <https://docs.nvidia.com/cuda/profiler-users-guide/index.html>`_
+
+Cluster Modules
+^^^^^^^^^^^^^^^
+* :ref:`raplab-hackathon<hackathon_facility>`: ``module load cuda/10.1``

--- a/tools/nvidia-profiling-tools.rst
+++ b/tools/nvidia-profiling-tools.rst
@@ -49,6 +49,9 @@ Fine-grained kernel profile information can be captured using remote Nsight Comp
    
    nv-nsight-cu-cli -o profile --set full ./myapplication <arguments>
 
+.. note::
+   From CUDA 11.0.194, and Nsight Compute 2020.1.1, ``ncu`` is an alias of ``nv-nsight-cu-cli``
+
 
 This will capture the full set of available metrics, to populate all sections of the Nsight Compute GUI, however this can lead to very long run times to capture all the information.
 


### PR DESCRIPTION
Nsight Compute 2020.1.1 (at least in the ubuntu package) adds `ncu` as the preffered way to call nsight compute cli interface (matching `nsys` for nsight systems). 

This just adds a note about that, while still using the longer version in the body in case CUDA 11.0.194 is not available (due to release on 2020-07-07). 