### PR TITLE
Add note on sigill within nsys on bede

### DIFF
--- a/tools/nvidia-profiling-tools.rst
+++ b/tools/nvidia-profiling-tools.rst
@@ -40,6 +40,10 @@ See the `nsys profiling command switch options <https://docs.nvidia.com/nsight-s
    nsys profile -o timeline --trace cuda,nvtx,osrt,openacc ./myapplication <arguments>
 
 
+.. note:: 
+   On :ref:`Bede <bede_facility>` (Power9) the ``--trace`` option ``osrt`` can lead to ``SIGILL`` errors. As this is a default, consider passing ``--trace cuda,nvtx`` as an alternative minimum.
+
+
 Once this file has been downloaded to your local machine, it can be opened in ``nsys-ui``/``nsight-sys`` via ``File > Open > timeline.qdrep``: 
 
 


### PR DESCRIPTION
On Bede, if `nsys` attempts to trace `osrt` (a default option) `SIGILL` errors can occur, so reccommend an always passing a `--trace` option on bede.